### PR TITLE
Fix the St. Thomas debacle of December 2019

### DIFF
--- a/stthomasbot.py
+++ b/stthomasbot.py
@@ -58,16 +58,20 @@ while 1:
                             time.sleep(5)
                             print("New comment found at " + str(now()))
                             response = parse(comment.body)
-                            for res in response:
-                                #time.sleep(2)
-                                print(str(len(res)))
-                                comment = comment.reply(res + iamabot)
+                            if type(response) is list:
+                                for responsepart in response:
+                                    #time.sleep(2)
+                                    print(str(len(responsepart)))
+                                    comment = comment.reply(responsepart + iamabot)
+                                    print("Wrote response at " + str(now()))
+                            else:
+                                comment.reply(response + iamabot)
                                 print("Wrote response at " + str(now()))
                             print("Finished full quote at at " + str(now()) + ". Ready to begin quoting the Summa.")
     except KeyboardInterrupt:
         print("Exiting...")
         sys.exit()
     except Exception as e:
-	print(e)
+	    print(e)
         print("There was an error. Restarting...")
         flag = 1


### PR DESCRIPTION
Because parse( ) can return either a list or a string, the for loop that iterates over its output can actually lead to a catastrophic failure case when parse( ) outputs the error message explaining the bot syntax.  This fix should check the output from parse( ) and behave accordingly.